### PR TITLE
move back to pure upstream version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "secp256k1_wrapper/secp256k1"]
 	path = vendor/secp256k1
-	url = https://github.com/status-im/secp256k1.git
+	url = https://github.com/bitcoin-core/secp256k1.git
 	branch = master

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -57,6 +57,5 @@ pipeline {
     }
   }
   post {
-    always { cleanWs() }
   }
 }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -56,6 +56,4 @@ pipeline {
       }
     }
   }
-  post {
-  }
 }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -35,25 +35,26 @@ pipeline {
     }
 
     stage('Tests') {
-      parallel {
-        stage('C') {
-          environment {
-            NIMLANG = 'c'
-          }
-          steps {
-            sh 'nimble test'
-          }
+      stage('C') {
+        environment {
+          NIMLANG = 'c'
         }
+        steps {
+          sh 'nimble test'
+        }
+      }
 
-        stage('C++') {
-          environment {
-            NIMLANG = 'cpp'
-          }
-          steps {
-            sh 'nimble test'
-          }
+      stage('C++') {
+        environment {
+          NIMLANG = 'cpp'
+        }
+        steps {
+          sh 'nimble test'
         }
       }
     }
+  }
+  post {
+    always { cleanWs() }
   }
 }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -34,23 +34,21 @@ pipeline {
       }
     }
 
-    stage('Tests') {
-      stage('C') {
-        environment {
-          NIMLANG = 'c'
-        }
-        steps {
-          sh 'nimble test'
-        }
+    stage('C') {
+      environment {
+        NIMLANG = 'c'
       }
+      steps {
+        sh 'nimble test'
+      }
+    }
 
-      stage('C++') {
-        environment {
-          NIMLANG = 'cpp'
-        }
-        steps {
-          sh 'nimble test'
-        }
+    stage('C++') {
+      environment {
+        NIMLANG = 'cpp'
+      }
+      steps {
+        sh 'nimble test'
       }
     }
   }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
       }
     }
 
-    stage('C') {
+    stage('Tests: C') {
       environment {
         NIMLANG = 'c'
       }
@@ -43,7 +43,7 @@ pipeline {
       }
     }
 
-    stage('C++') {
+    stage('Tests: C++') {
       environment {
         NIMLANG = 'cpp'
       }

--- a/secp256k1.nimble
+++ b/secp256k1.nimble
@@ -20,7 +20,7 @@ let verbose = getEnv("V", "") notin ["", "0"]
 let styleCheckStyle = if (NimMajor, NimMinor) < (1, 6): "hint" else: "error"
 let cfg =
   " --styleCheck:usages --styleCheck:" & styleCheckStyle &
-  (if verbose: "" else: " --verbosity:0 --hints:off") &
+  (if verbose: "" else: " --verbosity:3 --hints:on") &
   " --skipParentCfg --skipUserCfg --outdir:build --nimcache:build/nimcache -f"
 
 proc build(args, path: string) =

--- a/secp256k1.nimble
+++ b/secp256k1.nimble
@@ -20,7 +20,7 @@ let verbose = getEnv("V", "") notin ["", "0"]
 let styleCheckStyle = if (NimMajor, NimMinor) < (1, 6): "hint" else: "error"
 let cfg =
   " --styleCheck:usages --styleCheck:" & styleCheckStyle &
-  (if verbose: "" else: " --verbosity:3 --hints:on") &
+  (if verbose: "" else: " --verbosity:0 --hints:off") &
   " --skipParentCfg --skipUserCfg --outdir:build --nimcache:build/nimcache -f"
 
 proc build(args, path: string) =


### PR DESCRIPTION
With `ecdh_raw` no longer needed, we can switch back to the original upstream version and stop maintaining a fork.