### PR TITLE
Better default linkage

### DIFF
--- a/secp256k1/abi.nim
+++ b/secp256k1/abi.nim
@@ -12,11 +12,17 @@ when defined(amd64) and (defined(gcc) or defined(clang)):
 else:
   const asmFlags = ""
 
+when (defined(gcc) or defined(clang)) and not defined(secp256k1DefaultSymbolsExport):
+  const apiDefines = " -DSECP256K1_API= -DSECP256K1_API_VAR=extern"
+else:
+  const apiDefines = ""
+
 const compileFlags =
   "-DENABLE_MODULE_ECDH=1 -DENABLE_MODULE_RECOVERY=1 -DENABLE_MODULE_SCHNORRSIG=1 -DENABLE_MODULE_EXTRAKEYS=1" &
   " -I" & quoteShell(internalPath) &
   " -I" & quoteShell(srcPath) &
-  asmFlags
+  asmFlags &
+  apiDefines
 
 {.compile(srcPath & "/secp256k1.c", compileFlags).}
 {.compile: srcPath & "/precomputed_ecmult.c".}


### PR DESCRIPTION
`SECP256K1_API` are defined as `__attribute__(visibility("default"))`, which might make sense compiling secp256k1 original as a dynamic library, but it makes less sense when it is wrapped in a nim library as it results in linker exporting all symbols marked with `SECP256K1_API` and `SECP256K1_API_VAR`, which in its turn prevents dead code elimination and grows the resulting binary size significantly (in case of wasm compilation it's ~ 1.5Mb). This PR introduces a better default, with an escape hatch (`-d:secp256k1DefaultSymbolsExport`).